### PR TITLE
comp.py: add csv output + replace digest with hexdigest

### DIFF
--- a/src/comp.py
+++ b/src/comp.py
@@ -15,6 +15,7 @@ import os
 import h5py
 import getopt
 import sys
+import csv
 import hashlib
 try:
     from mpi4py import MPI
@@ -237,7 +238,7 @@ class Caller():
 
             with h5py.File(output_filename, 'w') as output:
 
-                digest = hashlib.sha256(open(filename, 'rb').read()).digest()
+                digest = str(hashlib.sha256(open(filename, 'rb').read()).hexdigest())
                
                 create_attrs_in_comp_file(output,precision,utimeout,os.uname()[1],measure_name)
 
@@ -289,6 +290,15 @@ class Caller():
                 with open('report.txt', "a") as report_file:
                     print   (list_print, file=report_file)
 
+                with open('report.csv', 'a', newline='') as csv_f:
+                    fieldnames = ['solver']
+                    fieldnames.extend(attrs.keys())
+                    writer = csv.DictWriter(csv_f, fieldnames=fieldnames)
+                    if csv_f.tell() == 0:
+                        writer.writeheader()
+                    d = attrs
+                    d['solver'] = solver.name()
+                    writer.writerow(d)
 
     @timeout(utimeout)
     def _internal_call(self, solver, problem, filename, pfilename, output_filename):
@@ -316,7 +326,7 @@ class Caller():
             flpops = None
             mflops = None
 
-            digest = hashlib.sha256(open(filename, 'rb').read()).digest()
+            digest = str(hashlib.sha256(open(filename, 'rb').read()).hexdigest())
 
             if psize is not None:
                 solver_problem_data.create_dataset(np.string_('reactions'),
@@ -469,11 +479,7 @@ class Caller():
             attrs.create('nc', numberOfDegreeofFreedomContacts(filename))
             attrs.create('nds', numberOfDegreeofFreedom(filename))
             attrs.create('cond_nc', cond_problem(filename))
-            if b'\x00' in digest:
-                print('null character x00 in digest ' , digest)
-                print('Warning: the attribute is not created')
-            else:
-                attrs.create('digest', digest)
+            attrs.create('digest', digest)
             attrs.create('info', info)
             attrs.create('iter', iter)
             attrs.create('err', err)
@@ -517,6 +523,15 @@ class Caller():
             with open('report.txt', "a") as report_file:
                 print   (list_print, file=report_file)
 
+            with open('report.csv', 'a', newline='') as csv_f:
+                fieldnames = ['solver']
+                fieldnames.extend(attrs.keys())
+                writer = csv.DictWriter(csv_f, fieldnames=fieldnames)
+                if csv_f.tell() == 0:
+                    writer.writeheader()
+                d = attrs
+                d['solver'] = solver.name()
+                writer.writerow(d)
 
 
 


### PR DESCRIPTION
This PR adds a csv output which I find more convenient than tthe .txt output (which is kept). There is a CSV mode in emacs with the possibility to indent the columns and the file may be imported easily nearly everywhere.  Also it replaces digest with hexdigest which is human readable and also more convenient to write as a string in hdf5 file.
